### PR TITLE
introduced load hack to lib.c

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -4,6 +4,15 @@
 
 #include <mkl.h>
 
+#if 1
+__attribute__((constructor)) static void fixmkl(){
+  dlopen("libmkl_intel_lp64.so",RTLD_LAZY|RTLD_NOLOAD|RTLD_GLOBAL);
+  //dlopen("libmkl_intel_thread.so",RTLD_LAZY|RTLD_NOLOAD|RTLD_GLOBAL);
+  dlopen("libmkl_sequential.so",RTLD_LAZY|RTLD_NOLOAD|RTLD_GLOBAL);
+  dlopen("libmkl_core.so",RTLD_LAZY|RTLD_NOLOAD|RTLD_GLOBAL);
+}
+#endif
+
 void this_mkl_wrapper()
 {
   printf("Hello from library\n");

--- a/lib.c
+++ b/lib.c
@@ -5,6 +5,7 @@
 #include <mkl.h>
 
 #if 1
+#include <dlfcn.h>
 __attribute__((constructor)) static void fixmkl(){
   dlopen("libmkl_intel_lp64.so",RTLD_LAZY|RTLD_NOLOAD|RTLD_GLOBAL);
   //dlopen("libmkl_intel_thread.so",RTLD_LAZY|RTLD_NOLOAD|RTLD_GLOBAL);


### PR DESCRIPTION
Hi @mestar99,

Are you the "Anonymous92" in that thread?

Recently I had similar issue and I was able to fix it by dlopen hack. With my patch, main_basic_local works as expected. Please take a look.

By the way I wrote that code because CMake does not default to libmkl_rt.so. If you manually write makefile, I recommend linking libmkl_rt. I performed some research and found that libmkl_rt seems to just perform the dlopen.

(In that thread I don't know what `Dynamically link the shared objects into the executable. But this adds MKL dependencies on the executable when they may not be needed` means. Dynamic linking is linking on demand.)